### PR TITLE
[Fix] 5 vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,12 +3341,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -5087,9 +5087,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7334,9 +7334,9 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.4.tgz",
-      "integrity": "sha512-OEESQuwxMza803knC1YSt7NMuc1BrK9j7gZhCSs2WAyxr1vfiI7QLaLOKTh5c9SWGz98qVyQUbK8/WckevNQhg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",


### PR DESCRIPTION
express  <4.19.2
Severity: moderate
Express.js Open Redirect in malformed URLs - https://github.com/advisories/GHSA-rv95-896h-c2vc fix available via `npm audit fix`
node_modules/express
  @nestjs/platform-express  <=10.3.5
  Depends on vulnerable versions of express
  node_modules/@nestjs/platform-express

mysql2  <=3.9.3
Severity: critical
mysql2 Remote Code Execution (RCE) via the readCodeFor function - https://github.com/advisories/GHSA-fpw7-j2hg-69v5 mysql2 vulnerable to Prototype Poisoning - https://github.com/advisories/GHSA-49j4-86m8-q2jw mysql2 cache poisoning vulnerability - https://github.com/advisories/GHSA-mqr2-w7wj-jjgr fix available via `npm audit fix`
node_modules/mysql2

sanitize-html  <2.12.1
Severity: moderate
sanitize-html Information Exposure vulnerability - https://github.com/advisories/GHSA-rm97-x556-q36h fix available via `npm audit fix`
node_modules/sanitize-html

tar  <6.2.1
Severity: moderate
Denial of service while parsing a tar file due to lack of folders count validation - https://github.com/advisories/GHSA-f5x3-32g6-xq36 fix available via `npm audit fix`
node_modules/tar